### PR TITLE
Remove auto-link to old website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # myopenstories
-Designed to encourage the sharing of interactive stories created by the community for the community, the website formerly named www.mhios.com is an open repository for stories in the STUdio format, a set of tools to read and create interactive stories with possibility to transfer from and to the lunii story teller device.
+Designed to encourage the sharing of interactive stories created by the community for the community, the website formerly named mhios.com is an open repository for stories in the STUdio format, a set of tools to read and create interactive stories with possibility to transfer from and to the lunii story teller device.
 
 This website is now offline. This repository contains the Django/js/html... sources required to run the server. This was my first step into Django, js and web development, coding may not be always optimal.
 


### PR DESCRIPTION
As the website is squatted, it may be a bad idea to redirect public.

Thanx for the work, and the inspiration :-)

![image](https://user-images.githubusercontent.com/8625432/184528411-2b5f982f-fa37-402f-810e-5120d4ebfb28.png)
